### PR TITLE
add terraform_version - 0.11.14 & 0.12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ services:
 env:
   - TERRAFORM_VERSION=0.11.11
   - TERRAFORM_VERSION=0.11.13
+  - TERRAFORM_VERSION=0.11.14
+  - TERRAFORM_VERSION=0.12.2
 
 script:
   - bin/build.sh


### PR DESCRIPTION
add terraform version 

- 0.11.14
- 0.12.2

0.12.2 는 0.11.x 버전과 syntax 가 다르므로, 사용시 주의 요망 